### PR TITLE
worker_init_fn is redundant

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -115,7 +115,6 @@ def create_dataloader(
         collate_fn      = getattr(ds, 'collate_fn', None),
         num_workers     = num_workers, 
         pin_memory      = True,
-        worker_init_fn  = lambda x: np.random.seed(torch.randint(0,1000,(1,))[0].item()+x),
         **kw
     )
 


### PR DESCRIPTION
Just for the sake of completeness, I just checked that the `worker_init_fn=` function is not necessary in this code.
It would be necessary if we were using any `numpy.random.*` functions inside `Dataset.__getitem__()` to make sure they actually generate random numbers. 