### PR TITLE
Corrected float32 to uint8 image data conversion

### DIFF
--- a/clumpfinder.py
+++ b/clumpfinder.py
@@ -59,6 +59,7 @@ def main(args:argparse.Namespace) -> bool:
 
     if args.colorize:
         output_colorized = src.data.load_image(args.input_path, "RGB").permute(1, 2, 0)
+        output_colorized = (output_colorized * 255).to(torch.uint8)
         for id in clumps_list.keys():
             
             sample_clump = clumps_list[id]

--- a/src/data.py
+++ b/src/data.py
@@ -44,10 +44,8 @@ def save_image(path:str, imagedata_f32:np.ndarray) -> None:
     imagedata_u8 = (imagedata_f32 * 255).astype('uint8')
     PIL.Image.fromarray(imagedata_u8).save(path)
 
-def save_image_RGB(path:str, imagedata_f32:np.ndarray) -> None:
-    assert imagedata_f32.dtype == np.float32
-    assert 0.0 <= imagedata_f32.min() and imagedata_f32.max() <= 1.0
-    imagedata_u8 = (imagedata_f32 * 255).astype('uint8')
+def save_image_RGB(path:str, imagedata_u8:np.ndarray) -> None:
+    assert imagedata_u8.dtype == np.uint8
     if np.shape(imagedata_u8)[0] == 3:
         np.transpose(imagedata_u8, [1,2,0])
     PIL.Image.fromarray(imagedata_u8, mode='RGB').save(path)


### PR DESCRIPTION
Fixed image data conversion mistake introduced in d8664cc4a38168241ba56b3af59fe78df1e808a7 causing black output images.
@GabrielAngres31 